### PR TITLE
fix(preview): CV HTML blocks and tel: links (v2.6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Offline Markdown to PDF in the browser. No server, no uploads.",
   "keywords": [
     "markdown",
@@ -29,6 +29,7 @@
     "react-dom": "^19.2.4",
     "react-helmet": "^6.1.0",
     "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "styled-components": "^6.3.12",
     "workbox-build": "^7.4.0",

--- a/src/App/Components/Markdown/Previewer/Preview.js
+++ b/src/App/Components/Markdown/Previewer/Preview.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import hljs from 'highlight.js';
+import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import 'highlight.js/styles/github.css';
 
@@ -20,6 +21,15 @@ const highlight = (str, lang) => {
   }
 
   return '';
+};
+
+/** react-markdown's defaultUrlTransform drops `tel:` (CV contact rows); keep it. */
+const urlTransform = (value) => {
+  const v = String(value || '').trim();
+  if (/^tel:/i.test(v)) {
+    return v;
+  }
+  return defaultUrlTransform(value);
 };
 
 export default ({ source, children }) => {
@@ -52,7 +62,12 @@ export default ({ source, children }) => {
   };
 
   return (
-    <ReactMarkdown skipHtml remarkPlugins={[remarkGfm]} components={components}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw]}
+      urlTransform={urlTransform}
+      components={components}
+    >
       {markdownSource}
     </ReactMarkdown>
   );

--- a/src/App/Components/Markdown/Previewer/Preview.test.js
+++ b/src/App/Components/Markdown/Previewer/Preview.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Preview from './Preview.js';
+
+test('renders embedded raw HTML (e.g. CV contact tables)', () => {
+  const source = [
+    '<table><tbody><tr><td>user@example.com</td></tr></tbody></table>',
+    '',
+    '## Summary',
+    '',
+    'Body text.',
+  ].join('\n');
+
+  const { container } = render(<Preview source={source} />);
+
+  expect(container.querySelector('table')).toBeTruthy();
+  expect(container.textContent).toContain('user@example.com');
+  expect(container.textContent).toContain('Summary');
+  expect(container.textContent).toContain('Body text.');
+});
+
+test('renders nested HTML tables and mailto links like a CV header', () => {
+  const source = [
+    '<!-- Contacts -->',
+    '<table style="width: 100%;">',
+    '  <tr>',
+    '    <td><img alt="Photo" src="https://example.com/p.png" /></td>',
+    '    <td>',
+    '      <table><tr>',
+    '        <td><p><strong>Email:</strong> <a href="mailto:test@example.com">test@example.com</a></p></td>',
+    '        <td><p><strong>Location:</strong> Munich</p></td>',
+    '      </tr></table>',
+    '    </td>',
+    '  </tr>',
+    '</table>',
+    '',
+    '## Experience',
+    '',
+    'Role.',
+  ].join('\n');
+
+  const { container } = render(<Preview source={source} />);
+
+  expect(container.querySelectorAll('table').length).toBeGreaterThanOrEqual(2);
+  expect(
+    container.querySelector('a[href="mailto:test@example.com"]'),
+  ).toBeTruthy();
+  expect(container.textContent).toContain('Munich');
+  expect(container.textContent).toContain('Experience');
+});
+
+test('renders full CV-style contacts HTML (nested tables, photo, tel/mailto)', () => {
+  const source = [
+    '<!-- Contacts -->',
+    '<!-- Photo included -->',
+    '<table style="width: 100%; border-collapse: collapse;">',
+    '  <tr style="border: none; background: none;">',
+    '    <td style="width: 125px; vertical-align: middle; border: none; background: none; padding: 10px 10px 12px 0;">',
+    '      <img src="https://example.com/photo.jpg" alt="Candidate" style="border-radius: 50%; width: 100%; border: 2px solid #ccc;">',
+    '    </td>',
+    '    <td style="border: none; background: none; vertical-align: middle;">',
+    '      <table style="width: 100%; border-collapse: collapse;">',
+    '        <tr style="border: none; background: none; vertical-align: middle;">',
+    '          <td style="padding: 0 24px 0 3px; border: none; background: none;">',
+    '            <p style="margin: 0 0 4px 0;"><strong>Email:</strong> <a href="mailto:cv@example.com">cv@example.com</a></p>',
+    '            <p style="margin: 0 0 4px 0;"><strong>Phone:</strong> <a href="tel:+15555550100">+1 555-555-0100</a></p>',
+    '            <p style="margin: 0 0 4px 0;"><strong>LinkedIn:</strong> <a href="https://linkedin.com/in/example">linkedin.com/in/example</a></p>',
+    '          </td>',
+    '          <td style="padding: 0 24px 0 3px; border: none; background: none;">',
+    '            <p style="margin: 0 0 4px 0;"><strong>Website:</strong> <a href="https://example.com">example.com</a></p>',
+    '            <p style="margin: 0 0 4px 0;"><strong>Location:</strong> Munich, Germany</p>',
+    '            <p style="margin:0 0 4px 0;"><strong>Work Status:</strong> EU, unrestricted</p>',
+    '          </td>',
+    '        </tr>',
+    '      </table>',
+    '    </td>',
+    '  </tr>',
+    '</table>',
+    '',
+    '## Summary',
+    '',
+    'Intro.',
+  ].join('\n');
+
+  const { container } = render(<Preview source={source} />);
+
+  expect(container.querySelector('img[alt="Candidate"]')).toBeTruthy();
+  expect(container.querySelector('a[href="mailto:cv@example.com"]')).toBeTruthy();
+  expect(container.querySelector('a[href="tel:+15555550100"]')).toBeTruthy();
+  expect(container.textContent).toContain('Work Status:');
+  expect(container.textContent).toContain('EU, unrestricted');
+  expect(container.textContent).toContain('Summary');
+  expect(container.textContent).toContain('Intro.');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,6 +3236,46 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
@@ -3257,12 +3297,36 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
+  integrity sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 highlight.js@^11.11.1:
   version "11.11.1"
@@ -3280,6 +3344,11 @@ html-url-attributes@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
   integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 iconv-lite@0.6:
   version "0.6.3"
@@ -4480,6 +4549,13 @@ parse-entities@^4.0.0:
     is-decimal "^2.0.0"
     is-hexadecimal "^2.0.0"
 
+parse5@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parse5@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.0.tgz#aceb267f6b15f9b6e6ba9e35bfdd481fc2167b12"
@@ -4763,6 +4839,15 @@ regjsparser@^0.13.0:
   integrity sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==
   dependencies:
     jsesc "~3.1.0"
+
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
 
 remark-gfm@^4.0.1:
   version "4.0.1"
@@ -5545,6 +5630,14 @@ uuid@^11.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.3.tgz#87b44dddd7b70f0641c2e3ed0864ba73e2ea8df4"
@@ -5657,6 +5750,11 @@ w3c-xmlserializer@^5.0.0:
   integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
   dependencies:
     xml-name-validator "^5.0.0"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Restores rendering of raw HTML embedded in Markdown (e.g. CV contact tables) by using `rehype-raw` instead of `skipHtml`.

`react-markdown`'s default URL sanitizer allows `mailto`/`https` but strips `tel:`; added a small `urlTransform` so phone links in HTML work.

Includes regression tests modeled on a CV contacts section. Bumps package version to 2.6.1.