### PR TITLE
chore(security): patch DOMPurify + postcss runtime alerts and add security plan

### DIFF
--- a/SECURITY_PLAN.md
+++ b/SECURITY_PLAN.md
@@ -1,0 +1,115 @@
+# Security plan for md2pdf.marcopontili.com
+
+This is a **draft plan**, not implemented yet. The goal is to harden the public site against bad actors abusing it for XSS, content laundering, or social-engineering vectors. The app is purely client-side (no server, no auth, no DB), so the threat model is narrower than a typical webapp — but not empty.
+
+## Threat model
+
+The app accepts arbitrary markdown from the user and renders it client-side. There are three realistic abuse vectors:
+
+1. **Stored / reflected XSS via shared markdown** — if a future feature lets users share a URL that contains markdown content (?source= param, gist import, etc.), a malicious `<script>` or `onerror=` attribute injected via [rehype-raw](https://github.com/rehypejs/rehype-raw) executes in the victim's browser. Currently the editor only ingests local input, so this is latent — but the `rehype-raw` plumbing means the *capability* to render raw HTML exists today.
+2. **Phishing / brand-impersonation pages exported as PDF** — bad actors paste markdown that mimics a bank statement, government letter, etc., export to PDF, and share it. The site's URL appearing in the document footer (or in metadata) lends false authenticity. Mitigation: PDF metadata + visible watermark.
+3. **Supply-chain via vulnerable transitive deps** — the Dependabot alerts (DOMPurify <3.4.0, postcss <8.5.10, uuid <14.0.0, vite <8.0.5) are real. DOMPurify in particular is the sanitizer mermaid uses for SVG output; a bypass = XSS via a crafted mermaid block. This is the highest-priority concrete risk.
+
+What's **out of scope**:
+- No login → no credential theft / session hijacking
+- No backend → no SQL/SSRF/RCE
+- No PII storage → no data exfiltration via the app itself
+- The exported PDF runs in the user's PDF viewer, not in our origin → cross-origin escape from the PDF is the viewer's problem, not ours
+
+## Layered hardening
+
+### Layer 1 — patch known CVEs (do now, this PR)
+- Bump `vite` to `^8.0.10` (fixes 3 dev-server CVEs — only affects developers, but free win)
+- Add yarn `resolutions`:
+  - `dompurify: ^3.4.0` — fixes 4 RCE/XSS bypasses; mermaid 11 declares `^3.3.1`, so 3.4.x satisfies semver
+  - `postcss: ^8.5.10` — fixes the `</style>` stringify XSS; styled-components depends on `^8.x`, compatible
+  - **Skip uuid for now**: the alert is for `uuid <14.0.0`, but mermaid pins `^11.1.0` and the bug is in the v3/v5/v6 buf-bounds path, which mermaid doesn't use (it uses v4). Force-bumping to v14 is a major version jump and risks breaking mermaid for an unexploitable code path. Document the deferral in the PR.
+
+Verify by running `yarn audit --level moderate` and confirming the four fixed alerts disappear.
+
+### Layer 2 — Content Security Policy (next PR)
+Add a meta CSP in [index.html](index.html). Strict because the app is fully self-contained:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="
+  default-src 'self';
+  script-src 'self' 'wasm-unsafe-eval';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: https:;
+  font-src 'self' data:;
+  connect-src 'self';
+  frame-ancestors 'none';
+  base-uri 'self';
+  form-action 'none';
+  object-src 'none';
+">
+```
+
+Notes:
+- `'unsafe-inline'` for `style-src` is required by styled-components and react-markdown's inline-style codepaths. Acceptable: style injections can't run JS.
+- `'wasm-unsafe-eval'` is needed by Vite's rolldown WASM binding in production (used by the build, not runtime — verify before shipping).
+- `img-src https:` allows users to embed remote images in their markdown (a common need for a CV/document tool).
+- `connect-src 'self'` blocks any future leak via `fetch()` to a third-party.
+- `frame-ancestors 'none'` blocks clickjacking from being framed by attacker pages.
+
+A real CSP via HTTP header is stronger than `<meta>`, but FTP hosting can't always set headers. If the FTP host allows `.htaccess`, add the same policy there as well — `.htaccess` already exists in the deploy artifacts for cache control, so adding `Header set Content-Security-Policy` is one line.
+
+### Layer 3 — sanitize user-rendered HTML (next PR)
+The `Preview.js` chain is `react-markdown → remark-gfm → rehype-raw`. `rehype-raw` lets any HTML through verbatim. Add `rehype-sanitize` after `rehype-raw` with a permissive-but-safe schema (allow tables, images, basic formatting; strip `<script>`, `on*` attributes, `javascript:` URLs):
+
+```js
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+
+const schema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes.a || []), 'target'],
+    img: ['src', 'alt', 'title', 'width', 'height', 'style'],
+    table: ['style'], tr: ['style'], td: ['style', 'colspan', 'rowspan'], th: ['style', 'colspan', 'rowspan'],
+  },
+  protocols: { ...defaultSchema.protocols, href: ['http', 'https', 'mailto', 'tel'] },
+};
+```
+
+Caveat: this slightly tightens the existing CV-rendering use case (the embedded HTML in [Preview.test.js:52](src/App/Components/Markdown/Previewer/Preview.test.js)). The existing tests give us a regression net.
+
+### Layer 4 — PDF watermark / attribution (next PR)
+Add a small footer to the printed output (only visible in `@media print`):
+
+```css
+@media print {
+  body::after {
+    content: "Generated with md2pdf.marcopontili.com — verify authenticity";
+    position: fixed; bottom: 4px; left: 0; right: 0;
+    text-align: center; font: 10px/1 sans-serif; color: #999;
+  }
+}
+```
+
+Bad actors will strip it, but it raises the bar for casual phishing and gives recipients a verification cue. Pair with a `<meta name="generator">` so PDF metadata also shows the source.
+
+### Layer 5 — robots / abuse posture (small ops items)
+- Already done: `<meta name="robots" content="noindex, nofollow">` in [Header/index.js:28](src/App/Components/Header/index.js)
+- Add a `/.well-known/security.txt` to the deploy with a contact email so researchers can report issues
+- Add a public `SECURITY.md` in the repo with the same email + the threat model summary (lets researchers know what's in scope)
+
+### Layer 6 — Subresource integrity for any future CDN scripts
+Currently the app loads zero third-party scripts at runtime. Document this as a hard rule in `CONTRIBUTING.md`: any new `<script src="https://cdn...">` must include a `integrity=` and `crossorigin=` attribute. If the rule's documented now, future PRs that violate it stand out in review.
+
+## Order of operations
+
+| When | What | Why |
+|---|---|---|
+| **This PR (chore/security-deps)** | Layer 1 patches | Closes the actual open Dependabot alerts |
+| Next PR | Layer 2 CSP + Layer 5 security.txt | Cheap, big risk reduction, no behavior change |
+| Next PR | Layer 3 sanitization + tests | Behavior-affecting; needs careful verification of the CV use case |
+| Later | Layer 4 watermark | Polish; adds value but not security-critical |
+
+## Verification
+
+For each layer, the verification steps:
+1. **Layer 1**: `yarn audit --level moderate` shows zero results, all four GitHub alerts auto-close after the merge
+2. **Layer 2**: Open DevTools → Security tab → confirm CSP active; try pasting `<script>alert(1)</script>` in editor → blocked, console shows CSP violation
+3. **Layer 3**: paste known-malicious test vectors (e.g. `<img src=x onerror=alert(1)>`) → renders as `<img>` only (no `onerror`)
+4. **Layer 4**: print preview the page, confirm watermark visible at bottom of every page

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
   "resolutions": {
     "@rollup/plugin-terser": "^1.0.0",
     "lodash-es": "^4.18.1",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "dompurify": "^3.4.0",
+    "postcss": "^8.5.10"
   },
   "browserslist": [
     ">0.2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,10 +2769,10 @@ dom-accessibility-api@^0.5.9:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
-dompurify@^3.3.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
-  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
+dompurify@^3.3.1, dompurify@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.1.tgz#521d04483ac12631b2aedf434a5f5390933b8789"
+  integrity sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -4450,7 +4450,7 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.11, nanoid@^3.3.7:
+nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -4643,19 +4643,10 @@ postcss-value-parser@^4.0.2:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.49:
-  version "8.4.49"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
-  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.1.1"
-    source-map-js "^1.2.1"
-
-postcss@^8.5.8:
-  version "8.5.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.8.tgz#6230ecc8fb02e7a0f6982e53990937857e13f399"
-  integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
+postcss@8.4.49, postcss@^8.5.10, postcss@^8.5.8:
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
+  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"


### PR DESCRIPTION
## Summary
Closes 5 of the 8 open Dependabot alerts (the 5 runtime ones).

| Alert | Package | Severity | Fix |
|---|---|---|---|
| #116 | dompurify | Medium | force >=3.4.0 via resolutions |
| #117 | dompurify | Medium | force >=3.4.0 via resolutions |
| #118 | dompurify | Medium | force >=3.4.0 via resolutions |
| #119 | dompurify | Medium | force >=3.4.0 via resolutions |
| #121 | postcss | Medium | force >=8.5.10 via resolutions |

DOMPurify is mermaid's SVG sanitizer — exploitable via a crafted mermaid block on the public site. Mermaid declares \`dompurify ^3.3.1\`; 3.4.x satisfies that semver. Verified locally:
\`\`\`
yarn why dompurify  →  Found "dompurify@3.4.1"
yarn why postcss    →  Found "postcss@8.5.10"
yarn test           →  10/10 passing
\`\`\`

## Deferred
- Three vite dev-server alerts (#113–#115). Dev-only impact (no production users affected). Direct \`vite\` bump in package.json triggers an Invariant Violation in yarn 1's classic linker (\"could not find a copy of vite to link in node_modules/vitest/node_modules\") because vitest carries a nested vite. Will fix in a follow-up that bumps vite + vitest together, or after migrating to yarn 4 / pnpm.
- One uuid alert (#120). uuid v14 dropped v3/v5/v6 buf-bounds path; the bug is in those paths but mermaid uses v4 only — not exploitable through this app. Forcing uuid to v14 is a major bump that risks breaking mermaid for an unexploitable code path.

## Security plan
Added [SECURITY_PLAN.md](SECURITY_PLAN.md) — six layers of hardening (CVE patches → CSP → rehype-sanitize → PDF watermark → robots/security.txt → SRI for any future CDN). This PR is layer 1; the rest land in follow-up PRs to keep changes reviewable.

## Test plan
- [x] \`yarn install\` succeeds and updates yarn.lock deterministically
- [x] All 10 tests pass
- [x] \`yarn build\` produces a valid dist/
- [ ] After merge: confirm GitHub auto-closes alerts #116–#119 and #121