### PR TITLE
feat(privacy): block search engines and AI training crawlers + v2.7.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,16 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'none'; object-src 'none'; frame-ancestors 'none';" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="generator" content="md2pdf.marcopontili.com" />
+  <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex, nocache" />
+  <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet" />
+  <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet" />
+  <meta name="GPTBot" content="noindex, nofollow" />
+  <meta name="ChatGPT-User" content="noindex, nofollow" />
+  <meta name="Google-Extended" content="noindex, nofollow" />
+  <meta name="anthropic-ai" content="noindex, nofollow" />
+  <meta name="ClaudeBot" content="noindex, nofollow" />
+  <meta name="PerplexityBot" content="noindex, nofollow" />
+  <meta name="CCBot" content="noindex, nofollow" />
   <title>Markdown To PDF - Convert Markdown to PDF Offline</title>
   <meta name="description"
     content="Convert Markdown to PDF directly in your browser. No uploads, no servers. 100% offline web app." />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Offline Markdown to PDF in the browser. No server, no uploads.",
   "keywords": [
     "markdown",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,85 @@
+# md2pdf is a privacy-first, fully client-side tool.
+# We deliberately keep it out of search and AI-training indexes.
+
 User-agent: *
+Disallow: /
+
+# Search engines (explicit, in case some don't honor the wildcard)
+User-agent: Googlebot
+Disallow: /
+
+User-agent: Bingbot
+Disallow: /
+
+User-agent: DuckDuckBot
+Disallow: /
+
+User-agent: Yandex
+Disallow: /
+
+User-agent: Baiduspider
+Disallow: /
+
+# AI training / LLM crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: cohere-training-data-crawler
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Timpibot
 Disallow: /


### PR DESCRIPTION
Privacy/sec hardening: keep md2pdf.marcopontili.com out of search indexes and AI training corpora.

## What
- Expanded \`public/robots.txt\` with explicit \`Disallow: /\` blocks for search engines (Googlebot, Bingbot, Yandex, Baidu, DuckDuckGo) and 20+ AI/LLM crawlers (GPTBot, ChatGPT-User, Google-Extended, anthropic-ai, ClaudeBot, PerplexityBot, cohere-ai, Bytespider, Amazonbot, Applebot-Extended, Meta-ExternalAgent, CCBot, etc.)
- Hardened meta tags in \`index.html\` itself (not just React Helmet, so pre-JS crawlers see them): \`noindex, nofollow, noarchive, nosnippet, noimageindex, nocache\`
- Bot-specific \`<meta name="GPTBot" content="noindex, nofollow">\` etc. for belt-and-suspenders coverage
- Version bump v2.7.1 → v2.7.2

## Why
md2pdf processes user CV/private documents client-side. Even though nothing is stored server-side, having the URL indexed invites:
- Scraping of UI text into LLM training data
- Casual discovery → easier social-engineering vector for phishing PDFs

We want zero search/AI footprint.

## Caveat
robots.txt is a polite request, not enforcement. Bad-faith bots ignore it. Combined with the existing CSP \`frame-ancestors 'none'\` and the new \`noindex\` headers, this is the strongest non-auth posture the static site allows.