### PR TITLE
fix(ci): upload to FTP root + v2.7.4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USERNAME_PRODUCTION }}
           password: ${{ secrets.FTP_PASSWORD_PRODUCTION }}
-          server-dir: /md2pdf.marcopontili.com/
+          server-dir: ./
           local-dir: ./dist/
           protocol: ftps
           port: 21

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Offline Markdown to PDF in the browser. No server, no uploads.",
   "keywords": [
     "markdown",


### PR DESCRIPTION
Previous deploy ran green but the live URL kept serving the old build because uploads landed in /md2pdf.marcopontili.com/ (sibling to the web root) instead of the document root. Switching server-dir to ./ uploads where the Netsons FTP user is chrooted.