### PR TITLE
fix(mermaid): restore missing text labels in diagrams

### DIFF
--- a/src/App/Components/Header/index.js
+++ b/src/App/Components/Header/index.js
@@ -100,6 +100,7 @@ export default styled(Header)`
       margin-left: 8px;
       padding: 0 12px;
       font-size: 14px;
+      font-weight: 400;
       border: 1px solid #d0d7de;
       border-radius: 6px;
       cursor: pointer;

--- a/src/App/Components/Markdown/Previewer/Mermaid.jsx
+++ b/src/App/Components/Markdown/Previewer/Mermaid.jsx
@@ -88,7 +88,7 @@ export default function Mermaid({ code }) {
   return (
     <div
       className="mermaid-diagram"
-      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } }) }}
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true, html: true } }) }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- DOMPurify's SVG-only profile was stripping `<foreignObject>` elements and their HTML children that Mermaid uses to render text labels inside diagrams
- Enabled the `html` and `svgFilters` profiles alongside `svg` so that labels survive sanitization while still keeping XSS protection

## Test plan
- [ ] Add a Mermaid diagram with text labels (flowchart, sequence, etc.) and verify labels render correctly in the preview
- [ ] Export to PDF and confirm labels appear in the printed output
- [ ] Verify no XSS vectors are introduced (DOMPurify still active)