### PR TITLE
release: v2.9.19 first-heading PDF title fix and Ctrl+P coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** only for incomplete work.
 
+## [2.9.19] - 2026-05-08
+
+- **Enhance:** Cover the browser's Ctrl/Cmd+P shortcut by deriving the PDF title via `beforeprint`/`afterprint` listeners.
+- **Enhance:** Fall back to `h2..h6` when no `h1` exists and strip filesystem-illegal characters from the suggested filename.
+- **Fix:** Print dialog now uses the first heading as the suggested PDF filename (was always silently reset before printing).
+
 ## [2.9.18] - 2026-05-06
 
 - **Fix:** Keep `.preview` mounted during the lazy Preview chunk load so cold-load Export and the mobile print path work.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.9.18",
+  "version": "2.9.19",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [
     "markdown",

--- a/src/App/Components/Header/index.js
+++ b/src/App/Components/Header/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { FileEarmarkPdfFill, Github } from 'react-bootstrap-icons';
 import UploadButton from './Upload.js';
@@ -9,19 +9,53 @@ const { version } = packageMeta;
 
 const SOURCE_REPO_URL = 'https://github.com/marcop135/md2pdf';
 
+const sanitizeForFilename = (raw) =>
+  (raw ?? '')
+    .replace(/[\\/:*?"<>|\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const derivePrintTitle = () => {
+  const previewEl = document.querySelector('.preview');
+  if (!previewEl) return '';
+  const headingEl =
+    previewEl.querySelector('h1') ??
+    previewEl.querySelector('h2, h3, h4, h5, h6');
+  if (!headingEl) return '';
+  return sanitizeForFilename(headingEl.textContent);
+};
+
 const Header = ({ className }) => {
+  // Swap document.title around print so the first heading becomes the suggested
+  // PDF filename. Listening for beforeprint/afterprint covers both the Export
+  // button and the browser's native Ctrl/Cmd+P shortcut.
+  useEffect(() => {
+    let savedTitle = null;
+
+    const handleBeforePrint = () => {
+      const candidate = derivePrintTitle();
+      if (!candidate) return;
+      savedTitle = document.title;
+      document.title = candidate;
+    };
+
+    const handleAfterPrint = () => {
+      if (savedTitle !== null) {
+        document.title = savedTitle;
+        savedTitle = null;
+      }
+    };
+
+    window.addEventListener('beforeprint', handleBeforePrint);
+    window.addEventListener('afterprint', handleAfterPrint);
+    return () => {
+      window.removeEventListener('beforeprint', handleBeforePrint);
+      window.removeEventListener('afterprint', handleAfterPrint);
+      if (savedTitle !== null) document.title = savedTitle;
+    };
+  }, []);
+
   const onTransform = async () => {
-    let candidateTitle = '';
-    const previewEl = document.querySelector('.preview');
-    const candidateTitleEl = previewEl?.querySelector('h1');
-    if (candidateTitleEl) {
-      candidateTitle = candidateTitleEl.innerText;
-      const currentTitle = document.title;
-      document.title = candidateTitle;
-      window.requestAnimationFrame(() => {
-        document.title = currentTitle;
-      });
-    }
     await waitForMermaidRenders();
     window.print();
   };


### PR DESCRIPTION
## Summary

- Fix the first-heading-as-PDF-title swap: was being silently reset before `window.print()` because the scheduled RAF restore fired during `await waitForMermaidRenders()`.
- Move the swap into `beforeprint`/`afterprint` listeners so it covers both the Export button and the browser's Ctrl/Cmd+P shortcut.
- Fall back to `h2..h6` when no `h1` exists; sanitize filesystem-illegal characters from the suggested filename.

## Test plan

- [x] `yarn test` (16 passed)
- [x] `yarn changelog:lint`
- [x] `yarn build`
- [ ] Manual: Export button on a doc starting with `# Hello World!` shows `Hello World` as the suggested PDF filename in Chromium and Firefox.
- [ ] Manual: Ctrl/Cmd+P on the same doc produces the same suggested filename.
- [ ] Manual: doc starting with `## Section` falls back to that heading.