### PR TITLE
release: v2.9.21 reliable mobile PDF filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-**Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** only for incomplete work.
+**Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** for incomplete work.
+
+## [2.9.20] - 2026-05-08
+
+- **Docs:** Tighten changelog header legend and rewrite vague historical entries in an action-first style.
 
 ## [2.9.19] - 2026-05-08
 
@@ -212,8 +216,12 @@
 
 ## [1.0.0] - 2025-06-24
 
-- **Chore:** Create the 1.0.0 release tag on this fork.
+- **Chore:** Stamp the 1.0.0 baseline tag for the fork; no code change versus 0.0.2.
 
 ## [0.0.2] - 2025-06-24
 
-- **Chore:** Create the 0.0.2 package metadata tag.
+- **Chore:** Stamp the 0.0.2 metadata baseline tag for the fork; no code change versus the upstream snapshot.
+
+---
+
+Forked from [realdennis/md2pdf](https://github.com/realdennis/md2pdf) (MIT) in April 2025; releases above cover this fork only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** for incomplete work.
 
+## [2.9.21] - 2026-05-08
+
+- **Fix:** Sync `document.title` to the first heading on edit so Android Firefox and Brave save PDFs with a real name.
+
 ## [2.9.20] - 2026-05-08
 
 - **Docs:** Tighten changelog header legend and rewrite vague historical entries in an action-first style.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.9.19",
+  "version": "2.9.20",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [
     "markdown",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.9.20",
+  "version": "2.9.21",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [
     "markdown",

--- a/src/App/Components/Header/index.js
+++ b/src/App/Components/Header/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { FileEarmarkPdfFill, Github } from 'react-bootstrap-icons';
 import UploadButton from './Upload.js';
@@ -9,52 +9,10 @@ const { version } = packageMeta;
 
 const SOURCE_REPO_URL = 'https://github.com/marcop135/md2pdf';
 
-const sanitizeForFilename = (raw) =>
-  (raw ?? '')
-    .replace(/[\\/:*?"<>|\r\n\t]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-const derivePrintTitle = () => {
-  const previewEl = document.querySelector('.preview');
-  if (!previewEl) return '';
-  const headingEl =
-    previewEl.querySelector('h1') ??
-    previewEl.querySelector('h2, h3, h4, h5, h6');
-  if (!headingEl) return '';
-  return sanitizeForFilename(headingEl.textContent);
-};
-
 const Header = ({ className }) => {
-  // Swap document.title around print so the first heading becomes the suggested
-  // PDF filename. Listening for beforeprint/afterprint covers both the Export
-  // button and the browser's native Ctrl/Cmd+P shortcut.
-  useEffect(() => {
-    let savedTitle = null;
-
-    const handleBeforePrint = () => {
-      const candidate = derivePrintTitle();
-      if (!candidate) return;
-      savedTitle = document.title;
-      document.title = candidate;
-    };
-
-    const handleAfterPrint = () => {
-      if (savedTitle !== null) {
-        document.title = savedTitle;
-        savedTitle = null;
-      }
-    };
-
-    window.addEventListener('beforeprint', handleBeforePrint);
-    window.addEventListener('afterprint', handleAfterPrint);
-    return () => {
-      window.removeEventListener('beforeprint', handleBeforePrint);
-      window.removeEventListener('afterprint', handleAfterPrint);
-      if (savedTitle !== null) document.title = savedTitle;
-    };
-  }, []);
-
+  // The Markdown component keeps document.title synced to the first heading
+  // so that any print path (this button, Ctrl/Cmd+P, browser menu, Android
+  // share-to-PDF) reads the right value. See src/App/Lib/printTitle.js.
   const onTransform = async () => {
     await waitForMermaidRenders();
     window.print();

--- a/src/App/Components/Markdown/index.js
+++ b/src/App/Components/Markdown/index.js
@@ -8,6 +8,7 @@ import DragBar from './DragBar.js';
 import 'github-markdown-css';
 import useDrop from '../../Container/Hooks/useDrop.js';
 import useIsMobile from '../../Container/Hooks/useIsMobile.js';
+import { DEFAULT_TITLE, extractHeading } from '../../Lib/printTitle.js';
 
 const Markdown = ({ className }) => {
   const [text, setText] = useProvided(TextContainer);
@@ -33,6 +34,23 @@ const Markdown = ({ className }) => {
       document.removeEventListener('touchcancel', handleTouchEnd);
     };
   }, []);
+
+  // Keep document.title synced to the first heading so the suggested PDF
+  // filename is correct on every print path. Android Firefox does not fire
+  // beforeprint reliably (saves as tempXXXX) and Chromium-on-Android reads
+  // document.title at window.print() invocation, so a beforeprint swap can
+  // arrive too late. A continuous sync makes the title correct in advance.
+  useEffect(() => {
+    const originalTitle = document.title;
+    return () => {
+      document.title = originalTitle;
+    };
+  }, []);
+
+  useEffect(() => {
+    const heading = extractHeading(text);
+    document.title = heading || DEFAULT_TITLE;
+  }, [text]);
 
   const handleMouseMove = (e) => {
     if (!isDrag) return;

--- a/src/App/Lib/printTitle.js
+++ b/src/App/Lib/printTitle.js
@@ -1,0 +1,38 @@
+export const DEFAULT_TITLE = 'Markdown to PDF';
+
+export const sanitizeForFilename = (raw) =>
+  (raw ?? '')
+    .replace(/[\\/:*?"<>|\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const stripInlineMarkdown = (text) =>
+  text
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/_([^_]+)_/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<\/?[^>]+>/g, '');
+
+const ATX = /^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/m;
+const SETEXT = /^[ \t]{0,3}([^\n]+?)[ \t]*\n[ \t]{0,3}=+[ \t]*$/m;
+const HTML_HEADING = /<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i;
+
+export const extractHeading = (markdown) => {
+  if (typeof markdown !== 'string' || markdown.length === 0) return '';
+
+  const candidates = [];
+  const atx = markdown.match(ATX);
+  if (atx) candidates.push({ index: atx.index, text: atx[1] });
+  const setext = markdown.match(SETEXT);
+  if (setext) candidates.push({ index: setext.index, text: setext[1] });
+  const html = markdown.match(HTML_HEADING);
+  if (html) candidates.push({ index: html.index, text: html[1] });
+
+  if (candidates.length === 0) return '';
+  candidates.sort((a, b) => a.index - b.index);
+  return sanitizeForFilename(stripInlineMarkdown(candidates[0].text));
+};

--- a/src/App/Lib/printTitle.test.js
+++ b/src/App/Lib/printTitle.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest';
+import {
+  DEFAULT_TITLE,
+  extractHeading,
+  sanitizeForFilename,
+} from './printTitle.js';
+
+describe('sanitizeForFilename', () => {
+  test('replaces filesystem-illegal characters with spaces', () => {
+    expect(sanitizeForFilename('a/b\\c:d*e?f"g<h>i|j')).toBe(
+      'a b c d e f g h i j',
+    );
+  });
+
+  test('collapses whitespace and trims', () => {
+    expect(sanitizeForFilename('  hello   world  ')).toBe('hello world');
+  });
+
+  test('handles null and undefined', () => {
+    expect(sanitizeForFilename(null)).toBe('');
+    expect(sanitizeForFilename(undefined)).toBe('');
+  });
+
+  test('strips embedded newlines and tabs', () => {
+    expect(sanitizeForFilename('line1\nline2\tend')).toBe('line1 line2 end');
+  });
+});
+
+describe('extractHeading', () => {
+  test('returns ATX h1', () => {
+    expect(extractHeading('# Hello world')).toBe('Hello world');
+  });
+
+  test('returns ATX h2 when no h1', () => {
+    expect(extractHeading('Some prose\n\n## Sub heading\nbody')).toBe(
+      'Sub heading',
+    );
+  });
+
+  test('handles ATX h6', () => {
+    expect(extractHeading('###### Tiny')).toBe('Tiny');
+  });
+
+  test('strips trailing closing hashes from ATX', () => {
+    expect(extractHeading('## Heading ##')).toBe('Heading');
+  });
+
+  test('returns Setext h1 when it appears first', () => {
+    expect(extractHeading('Setext title\n===\n\n# Later atx')).toBe(
+      'Setext title',
+    );
+  });
+
+  test('returns embedded HTML heading', () => {
+    expect(extractHeading('<h2>HTML heading</h2>\n\nbody')).toBe(
+      'HTML heading',
+    );
+  });
+
+  test('picks the earliest heading regardless of style', () => {
+    const md = '<h1>HTML first</h1>\n\n# ATX later';
+    expect(extractHeading(md)).toBe('HTML first');
+  });
+
+  test('strips inline emphasis and code from heading text', () => {
+    expect(extractHeading('# **Bold** _em_ `code` and [link](url)')).toBe(
+      'Bold em code and link',
+    );
+  });
+
+  test('sanitises filesystem-illegal characters in heading text', () => {
+    expect(extractHeading('# foo/bar:baz?')).toBe('foo bar baz');
+  });
+
+  test('returns empty string when no heading found', () => {
+    expect(extractHeading('just prose, nothing else')).toBe('');
+  });
+
+  test('returns empty string for empty input', () => {
+    expect(extractHeading('')).toBe('');
+    expect(extractHeading(null)).toBe('');
+    expect(extractHeading(undefined)).toBe('');
+  });
+
+  test('does not match heading inside fenced code block heuristics', () => {
+    // Conservative: we still match '#' anywhere; ensure leading whitespace cap.
+    // Indented by 4+ spaces (code block) should not match ATX.
+    expect(extractHeading('    # not a heading\n\n# Real one')).toBe(
+      'Real one',
+    );
+  });
+});
+
+describe('DEFAULT_TITLE', () => {
+  test('is the brand fallback string', () => {
+    expect(DEFAULT_TITLE).toBe('Markdown to PDF');
+  });
+});


### PR DESCRIPTION
## Summary

- Sync `document.title` to the markdown's first heading continuously so Android Firefox stops saving as `tempXXXX` and Brave stops using the static `<title>`.
- Drop the `beforeprint`/`afterprint` swap; the new approach makes any print path read the correct title at invocation time.
- New `src/App/Lib/printTitle.js` helper with 17 unit tests covers ATX, Setext, and embedded HTML headings plus filename sanitisation.

Ships as v2.9.21.

## Test plan

- [x] `yarn test` (33 passed).
- [x] `yarn build` clean.
- [x] `yarn changelog:lint` green.
- [ ] Verify on Samsung S21 / Brave + Firefox after deploy that PDF filename suggestion matches the first heading.
- [ ] Spot-check desktop Chrome + Firefox Ctrl/Cmd+P filename suggestion.