### PR TITLE
fix: dark-mode OS makes preview tables unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** for incomplete work.
 
+## [2.9.22] - 2026-05-10
+
+- **Fix:** Load the light-only `github-markdown-css` variant so tables stay readable when the OS is in dark mode.
+
 ## [2.9.21] - 2026-05-08
 
 - **Fix:** Sync `document.title` to the first heading on edit so Android Firefox and Brave save PDFs with a real name.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.9.21",
+  "version": "2.9.22",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [
     "markdown",

--- a/src/App/Components/Markdown/Previewer/index.js
+++ b/src/App/Components/Markdown/Previewer/index.js
@@ -2,7 +2,7 @@ import React, { Suspense, lazy } from 'react';
 import styled from 'styled-components';
 import Loading from './Loading';
 import ErrorBoundary from './ErrorBoundary.js';
-import 'github-markdown-css';
+import 'github-markdown-css/github-markdown-light.css';
 const Wrapper = styled.div`
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/App/Components/Markdown/index.js
+++ b/src/App/Components/Markdown/index.js
@@ -5,7 +5,7 @@ import { TextContainer } from '../../Container';
 import Previewer from './Previewer';
 import Editor from './Editor';
 import DragBar from './DragBar.js';
-import 'github-markdown-css';
+import 'github-markdown-css/github-markdown-light.css';
 import useDrop from '../../Container/Hooks/useDrop.js';
 import useIsMobile from '../../Container/Hooks/useIsMobile.js';
 import { DEFAULT_TITLE, extractHeading } from '../../Lib/printTitle.js';


### PR DESCRIPTION
## Summary

- Switch both `import 'github-markdown-css'` sites to the light-only `github-markdown-css/github-markdown-light.css` variant.
- Bump to v2.9.22 + changelog entry.

## Root cause

The auto-themed `github-markdown.css` redefines `--bgColor-default` / `--bgColor-muted` under `@media (prefers-color-scheme: dark)`. `<tr>` consumes those vars, so rows rendered with `#0d1117` / `#151b23` backgrounds while `styles.css` kept body text at `#24292e`, making tables unreadable when the OS was in dark mode. The light variant has no dark `@media` block.

## Test plan

- [x] `yarn test` (33/33)
- [x] `yarn build`
- [x] `yarn changelog:lint`
- [ ] Verify in browser with OS dark mode enabled that preview tables render light