### PR TITLE
release: v2.11.0 performance, accessibility, SEO, and code-quality audit

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: audit
+description: Run a full site optimization pass on md2pdf across performance/build, accessibility, SEO, and code quality, with before/after screenshot verification at desktop/tablet/mobile breakpoints. Use when the user asks to "audit", "optimize the site", "improve performance/a11y/SEO/code quality", or "run the audit workflow".
+---
+
+# Site audit and optimization workflow
+
+Orchestrate a four-track audit of this React 19 + Vite PWA, applying safe fixes in parallel and proving nothing broke visually. Follow these steps in order. Use the task tools to track progress.
+
+## Non-negotiable scope rules (read `CLAUDE.md` first)
+
+- Offline-first, client-only: no backend, no server-side conversion, no new network deps.
+- Never reorder `rehype-raw` -> `rehype-sanitize` and never remove `rehype-sanitize`. Never edit `src/App/Components/Markdown/Previewer/Preview.js` during cleanup.
+- `index.html` is deliberately `noindex, nofollow`: do NOT make the site indexable.
+- Mermaid must stay OUT of `manualChunks` (it self-splits; coalescing produces a >2 MB chunk that breaks the workbox precache and fails the build).
+- Don't add the em-dash character (U+2014).
+
+## Step 1 — Baseline screenshots
+
+1. Ensure the dev server is running: `npm start` (port 5173, fixed). If 5173 is bound, a Vite session is already up; reuse it.
+2. If Playwright is not installed: `npm install -D playwright @playwright/test && npx playwright install chromium`.
+3. Capture baselines: `node scripts/audit-screenshots.mjs screenshots/baseline`
+4. Read a couple of the PNGs to confirm the app rendered (not a blank/error page) before proceeding.
+
+## Step 2 — Four parallel audit agents (disjoint file ownership)
+
+Launch four `general-purpose` agents in a SINGLE message so they run concurrently. Give each a self-contained brief with the scope rules above and a STRICT, disjoint file-ownership list. Disjoint ownership is what makes parallel edits safe; never let two agents own the same file. Tell every agent: do NOT run `npm run build` / `npm start` / `npm run dev` (one dev server only; a central build runs afterward).
+
+Suggested ownership (adjust if the file tree changed):
+
+- **Performance / build** — `vite.config.js`, `public/.htaccess`, `src/serviceWorkerRegistration.js`, `src/App/Components/Markdown/Previewer/{index.js,Mermaid.jsx,Loading.js}`. Goals: vendor chunk splitting (NOT mermaid), lazy-load heavy deps, cache headers for hashed assets, keep PWA precache valid.
+- **Accessibility** — `src/App/Components/Header/{index.js,Upload.js}`, `src/App/Components/Markdown/index.js`, `src/App/Theme/index.js`, `src/styles.css`. Goals: ARIA tablist for the Editor/Preview tabs, `:focus-visible` rings, WCAG AA contrast, keyboard-focusable upload control, `prefers-reduced-motion`.
+- **SEO / metadata** — `index.html`, `public/manifest.json`, `public/robots.txt`. Goals: canonical, full OG/Twitter tags, JSON-LD `WebApplication` (data, CSP-safe; never add `'unsafe-inline'`), complete manifest. PRESERVE the noindex decision.
+- **Code quality** — the remaining `src/` files (hooks, `Lib/`, error boundaries, `Editor/`, `DragBar.js`, `src/index.js`). Explicitly off-limits: every file owned above, `Preview.js`, and `src/App/index.js` (print CSS). Behavior-preserving cleanup only; run `npm test` after.
+
+Tell each agent to report (under ~350 words): files changed, what changed, and anything deliberately skipped or that the central build should verify.
+
+## Step 3 — Central verification
+
+Run after all agents finish (avoids concurrent `dist/` writes):
+
+1. `npm test` — must stay green (35 tests at time of writing).
+2. `npm run build` — must succeed. Watch for the workbox `maximumFileSizeToCacheInBytes` error: if a chunk >2 MB appears, a vendor was over-coalesced in `manualChunks` (most often mermaid). Fix by letting it self-split or raising the limit, then rebuild.
+
+## Step 4 — Post-change screenshots and comparison
+
+1. `node scripts/audit-screenshots.mjs screenshots/after`
+2. Read the `after/*.png` and compare against `baseline/*.png` at all three breakpoints, including both mobile/tablet tab states.
+3. The screenshot script matches the Preview control as either `role="tab"` or `role="button"`, so an a11y change from button to tab won't silently drop the preview capture. If a `-preview.png` is missing, the tab toggle selector failed; fix the script rather than skipping the comparison.
+4. Any visual delta must be explained (e.g. an intentional AA contrast color shift). Unexplained layout/spacing changes are regressions to fix.
+
+## Step 5 — Document
+
+Update `CLAUDE.md` with any new conventions introduced (chunking strategy, a11y markup contracts, metadata constraints) so future sessions don't regress them. Keep additions free of em-dashes.
+
+## Notes
+
+- `screenshots/` is gitignored; it is scratch output, not committed.
+- Do not commit or push unless the user explicitly asks.

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ public/static/og-img.png
 # PWA PNG icons + favicon.ico rendered from public/favicon.svg + favicon-maskable.svg
 public/icons/
 public/favicon.ico
+
+# Audit screenshots rendered by scripts/audit-screenshots.mjs
+screenshots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** for incomplete work.
 
+## [2.11.0] - 2026-06-04
+
+- **Enhance:** Mark the mobile Editor/Preview switcher as an ARIA tablist with roving tabindex and arrow-key navigation.
+- **Enhance:** Add visible `:focus-visible` rings on toolbar controls and tabs via a theme `focusRing` token.
+- **Enhance:** Make the file-import control keyboard-focusable instead of a hidden, unreachable label.
+- **Enhance:** Add canonical, Open Graph url/type/site_name/locale, and JSON-LD WebApplication structured data.
+- **Enhance:** Complete the PWA manifest with id, scope, categories, lang, dir, and orientation.
+- **Fix:** Darken the light active-tab blue so the tab label meets WCAG AA contrast.
+- **Fix:** Log Previewer errors instead of silently swallowing them in the error boundary.
+- **Perf:** Dynamically import Mermaid so the print path no longer bundles the engine upfront.
+- **Perf:** Split react, codemirror, highlight.js, and markdown libraries into separate cached vendor chunks.
+- **Perf:** Cache hashed build assets as immutable for a year while keeping entry points no-cache.
+- **Docs:** Document build chunking, accessibility, metadata, and audit conventions in CLAUDE.md.
+- **Build:** Add a Playwright audit screenshot script and an `/audit` skill for repeatable site reviews.
+- **Chore:** Remove dead code and normalize quotes across hooks, editor, and error boundaries.
+
 ## [2.10.6] - 2026-06-02
 
 - **Enhance:** Accept `.markdown`, `.mdown`, and `.mkd` files on import, not just `.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,34 @@ PNG icons under `public/icons/` are **generated**, not hand-edited. Sources:
 
 To change the icon, edit the appropriate SVG source and re-run dev/build (or `npm run icons:sync`). Don't commit PNGs into the repo.
 
+## Build chunking and lazy loading
+
+`vite.config.js` defines `build.rollupOptions.output.manualChunks` that splits heavy vendors into their own content-hashed chunks: `react` (react/react-dom/scheduler), `codemirror` (@codemirror/@uiw/@lezer/codemirror), `highlight` (highlight.js), and `markdown` (react-markdown + the remark/rehype/micromark/unified stack). This keeps the initial entry chunk small.
+
+- **Mermaid is intentionally NOT in `manualChunks`.** It is dynamically imported in [`Mermaid.jsx`](src/App/Components/Markdown/Previewer/Mermaid.jsx) (`import('mermaid')`) and self-splits its diagram engines into many small chunks. Forcing it into one manual chunk coalesces those into a single >2 MB file that exceeds workbox's default `maximumFileSizeToCacheInBytes` (2 MiB) and **fails the build**. Leave mermaid out of the chunk rules.
+- The `waitForMermaidRenders()` export in `Mermaid.jsx` is imported by the Header's print handler; keep it exported. Because mermaid is dynamically imported, the Header no longer pulls the mermaid engine into the entry bundle.
+- All emitted chunks match the PWA precache glob (`**/*.js`), so offline support holds. If you add a vendor that produces a single chunk >2 MB, either let it self-split or raise `workbox.maximumFileSizeToCacheInBytes`.
+- `public/.htaccess` caches hashed `assets/*` as `immutable, max-age=31536000`; `index.html` / `sw.js` / `workbox-*.js` / `manifest.json` stay `no-cache`. Don't give entry points long-lived caching.
+
+## Accessibility conventions
+
+- The mobile/tablet (≤768px) Editor/Preview switcher in [`Markdown/index.js`](src/App/Components/Markdown/index.js) is a real ARIA tablist: `role="tablist"` on the bar, `role="tab"` + `aria-selected` + roving `tabIndex` + arrow/Home/End key nav on each tab, and `role="tabpanel"` + `aria-labelledby` on the panes. Keep this markup when editing the tabs; both panes stay mounted (print needs the Previewer in the DOM, hidden via screen-only `display:none`).
+- Interactive controls use `:focus-visible` outlines driven by the `focusRing` theme token (`src/App/Theme/index.js`: `#0969da` light, `#58a6ff` dark). Don't strip focus outlines.
+- The Upload control ([`Upload.js`](src/App/Components/Header/Upload.js)) is a visually-hidden but **keyboard-focusable** file `<input>` (absolute, `opacity:0`, in tab order), not `display:none`. Keep it focusable; `styles.css` gives `.button.upload:focus-within` a ring.
+- Theme colors are tuned to WCAG 2.1 AA; the light active-tab blue is `#0969da` (white label 5.19:1). Re-check contrast before changing palette values.
+- `prefers-reduced-motion` disables tab/button transitions and the active-press scale. Respect it for new animated controls.
+
+## SEO and metadata
+
+- `index.html` is **deliberately `noindex, nofollow`** (plus per-bot noindex for Google/Bing/GPTBot/ClaudeBot/etc.) and `public/robots.txt` `Disallow: /`s crawlers. This is intentional; **do not make the site indexable.** Metadata work here is about unfurl/install correctness, not ranking.
+- `index.html` carries a `canonical`, full Open Graph set (`og:title/description/image/url/type/site_name/locale`), Twitter card tags, and a JSON-LD `WebApplication` block. The JSON-LD is `type="application/ld+json"` (data, not executable JS) so it is allowed under the CSP `script-src 'self' 'wasm-unsafe-eval'`. **Never add `'unsafe-inline'` to `script-src`** to accommodate scripts.
+- `public/manifest.json` is complete (`id`, `scope`, `start_url: '/'`, `categories`, `lang`, `dir`, `orientation`, `theme_color` `#0d6efd` matching the meta). Keep `start_url`/`scope`/`id` consistent with the canonical root.
+
+## Auditing (performance / a11y / SEO / code quality)
+
+- `scripts/audit-screenshots.mjs` (Playwright, a devDependency) captures the key views at desktop (1280), tablet (768), and mobile (375) breakpoints, toggling the mobile Editor/Preview tabs. Usage: `node scripts/audit-screenshots.mjs <outDir> [baseUrl]` with the dev server running on 5173. Output (`screenshots/`) is gitignored.
+- The `/audit` skill (`.claude/skills/audit/`) reruns the full workflow: baseline screenshots, four parallel audit agents with disjoint file ownership, central `npm test` + `npm run build`, and a post-change screenshot comparison.
+
 ## Style and tooling
 
 - `.prettierrc` is the formatting source of truth.

--- a/index.html
+++ b/index.html
@@ -21,6 +21,11 @@
   <title>Free Markdown to PDF editor — offline and mobile-friendly</title>
   <meta name="description"
     content="Convert Markdown to PDF in your browser — GFM, syntax highlighting, Mermaid. Mobile-friendly, works offline, nothing uploaded.">
+  <link rel="canonical" href="https://md2pdf.marcopontili.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://md2pdf.marcopontili.com/">
+  <meta property="og:site_name" content="Markdown to PDF">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Free Markdown to PDF editor — offline and mobile-friendly">
   <meta property="og:description"
     content="Convert Markdown to PDF in your browser — GFM, syntax highlighting, Mermaid. Mobile-friendly, works offline, nothing uploaded.">
@@ -34,12 +39,30 @@
   <meta name="twitter:description"
     content="Convert Markdown to PDF in your browser — GFM, syntax highlighting, Mermaid. Mobile-friendly, works offline, nothing uploaded.">
   <meta name="twitter:image" content="https://md2pdf.marcopontili.com/static/og-img.png">
+  <meta name="twitter:image:alt" content="Free Markdown to PDF editor, offline and mobile-friendly.">
   <link rel="manifest" href="/manifest.json">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png">
   <link rel="icon" type="image/png" sizes="512x512" href="/icons/icon-512.png">
   <link rel="apple-touch-icon" href="/icons/icon-512.png">
   <meta name="theme-color" content="#0d6efd">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "Markdown to PDF",
+      "description": "Convert Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Mobile-friendly, works offline, nothing uploaded.",
+      "url": "https://md2pdf.marcopontili.com/",
+      "applicationCategory": "Utility",
+      "operatingSystem": "Any",
+      "browserRequirements": "Requires JavaScript.",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    }
+  </script>
 </head>
 
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "md2pdf",
-  "version": "2.10.3",
+  "version": "2.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "md2pdf",
-      "version": "2.10.3",
+      "version": "2.10.6",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -38,12 +38,14 @@
         "workbox-window": "^7.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@resvg/resvg-js": "^2.6.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^6.0.1",
         "esbuild": "^0.28.0",
         "jsdom": "^29.0.1",
+        "playwright": "^1.60.0",
         "react-test-renderer": "^19.2.4",
         "source-map-explorer": "^2.5.3",
         "vite": "^8.0.10",
@@ -1676,6 +1678,40 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "license": "MIT",
@@ -1690,6 +1726,431 @@
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.0",
@@ -1851,12 +2312,47 @@
         "@chevrotain/types": "~11.1.1"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@resvg/resvg-js": {
@@ -1881,6 +2377,205 @@
         "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
       }
     },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@resvg/resvg-js-win32-x64-msvc": {
       "version": "2.6.2",
       "cpu": [
@@ -1894,6 +2589,264 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
@@ -2114,6 +3067,17 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/aria-query": {
@@ -4101,6 +5065,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -5163,6 +6141,228 @@
         "lightningcss-linux-x64-musl": "1.32.0",
         "lightningcss-win32-arm64-msvc": "1.32.0",
         "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
@@ -6320,6 +7520,38 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/points-on-curve": {
@@ -7892,6 +9124,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vite/node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.10.6",
+  "version": "2.11.0",
   "packageManager": "npm@10.9.3",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [
@@ -46,12 +46,14 @@
     "workbox-window": "^7.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@resvg/resvg-js": "^2.6.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "^6.0.1",
     "esbuild": "^0.28.0",
     "jsdom": "^29.0.1",
+    "playwright": "^1.60.0",
     "react-test-renderer": "^19.2.4",
     "source-map-explorer": "^2.5.3",
     "vite": "^8.0.10",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1303,4 +1303,14 @@ FileETag None
         Header set Pragma "no-cache"
         Header set Expires "0"
     </FilesMatch>
+
+    # Vite emits content-hashed files into /assets/ (e.g. index-a1b2c3.js,
+    # mermaid-d4e5f6.js). The hash changes whenever the bytes change, so these
+    # are safe to mark `immutable`: browsers skip even the conditional
+    # revalidation round-trip until a new deploy ships a new filename. The
+    # 1-year max-age comes from ExpiresDefault above; `immutable` is the part
+    # that removes the needless If-None-Match traffic.
+    <FilesMatch "(^|/)assets/.*\.(js|mjs|css|woff2?|ttf|otf|svg|png|jpe?g|webp|avif|gif|ico)$">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </FilesMatch>
 </IfModule>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,15 @@
 {
+  "id": "/",
   "name": "Markdown to PDF",
   "short_name": "md2pdf",
-  "start_url": "/index.html",
+  "description": "Convert Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Mobile-friendly, works offline, nothing uploaded.",
+  "lang": "en",
+  "dir": "ltr",
+  "start_url": "/",
+  "scope": "/",
   "display": "standalone",
+  "orientation": "any",
+  "categories": ["productivity", "utilities"],
   "background_color": "#0d6efd",
   "theme_color": "#0d6efd",
   "icons": [

--- a/scripts/audit-screenshots.mjs
+++ b/scripts/audit-screenshots.mjs
@@ -1,0 +1,48 @@
+// Capture audit screenshots across breakpoints using Playwright.
+// Usage: node scripts/audit-screenshots.mjs <outDir> [baseUrl]
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+
+const outDir = process.argv[2] || 'screenshots/baseline';
+const baseUrl = process.argv[3] || 'http://localhost:5173';
+
+const viewports = [
+  { name: 'desktop-1280', width: 1280, height: 800, mobile: false },
+  { name: 'tablet-768', width: 768, height: 1024, mobile: true },
+  { name: 'mobile-375', width: 375, height: 812, mobile: true },
+];
+
+await mkdir(outDir, { recursive: true });
+const browser = await chromium.launch();
+
+for (const vp of viewports) {
+  const page = await browser.newPage({
+    viewport: { width: vp.width, height: vp.height },
+    deviceScaleFactor: 2,
+  });
+  await page.goto(baseUrl, { waitUntil: 'networkidle' });
+  // Let CodeMirror, styled-components and Mermaid settle.
+  await page.waitForTimeout(1500);
+
+  if (vp.mobile) {
+    // Mobile/tablet layout uses Editor/Preview tabs. Capture both.
+    await page.screenshot({ path: `${outDir}/${vp.name}-editor.png`, fullPage: false });
+    // The Preview control is a tab (role="tab"); older builds rendered it as a
+    // plain button. Match either so the script works across versions.
+    const previewTab = page
+      .getByRole('tab', { name: 'Preview' })
+      .or(page.getByRole('button', { name: 'Preview' }));
+    if (await previewTab.count()) {
+      await previewTab.first().click();
+      await page.waitForTimeout(800);
+      await page.screenshot({ path: `${outDir}/${vp.name}-preview.png`, fullPage: false });
+    }
+  } else {
+    await page.screenshot({ path: `${outDir}/${vp.name}.png`, fullPage: false });
+  }
+  await page.close();
+  console.log(`captured ${vp.name}`);
+}
+
+await browser.close();
+console.log(`Screenshots written to ${outDir}`);

--- a/src/App/Components/Header/Upload.js
+++ b/src/App/Components/Header/Upload.js
@@ -34,27 +34,29 @@ export default (props) => {
   };
   return (
     <p {...props} style={{ position: 'relative' }}>
+      {/* The file input stays keyboard-focusable but visually hidden (not
+          display:none, which removes it from the tab order). It is sized to
+          fill the control so a pointer click anywhere still opens the picker;
+          the parent gets a focus ring via :focus-within. */}
       <input
         id="mdFile"
         type="file"
-        style={{ display: 'none' }}
-        onChange={onChange}
-        accept=".md,.markdown,.mdown,.mkd"
-      />
-      <label
-        htmlFor="mdFile"
+        aria-label="Import .md file"
         style={{
           position: 'absolute',
-          opacity: 0,
           top: 0,
           left: 0,
-          right: 0,
-          bottom: 0,
+          width: '100%',
+          height: '100%',
+          opacity: 0,
+          margin: 0,
           zIndex: 2,
           cursor: 'pointer',
         }}
+        onChange={onChange}
+        accept=".md,.markdown,.mdown,.mkd"
       />
-      <FileEarmarkArrowUpFill size={18} aria-label="Import .md file" />
+      <FileEarmarkArrowUpFill size={18} aria-hidden />
       <span>Import .md file</span>
     </p>
   );

--- a/src/App/Components/Header/index.js
+++ b/src/App/Components/Header/index.js
@@ -205,8 +205,20 @@ export default styled(Header)`
         border-color: ${({ theme }) => theme.colors.buttonHoverBorder};
       }
 
+      &:focus-visible {
+        outline: 2px solid ${({ theme }) => theme.colors.focusRing};
+        outline-offset: 2px;
+      }
+
       &:active {
         transform: scale(0.97);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+        &:active {
+          transform: none;
+        }
       }
 
       &.primary svg {

--- a/src/App/Components/Markdown/Editor/index.js
+++ b/src/App/Components/Markdown/Editor/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-// import EditArea from './EditArea.js';
 import Mirror from './MirrorEditor.js';
 const Editor = ({ className, text, setText, width, isMobile }) => {
   return (

--- a/src/App/Components/Markdown/Previewer/ErrorBoundary.js
+++ b/src/App/Components/Markdown/Previewer/ErrorBoundary.js
@@ -2,38 +2,31 @@ import React from 'react';
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { error: null, errorInfo: null };
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
   }
   componentDidCatch(error, errorInfo) {
-    // Catch errors in any components below and re-render with error message
-    this.setState({
-      error: error,
-      errorInfo: errorInfo
-    });
-    // You can also log error messages to an error reporting service here
+    console.error('Preview crashed:', error, errorInfo);
   }
   render() {
-    if (this.state.errorInfo) {
-      // Error path
+    if (this.state.hasError) {
       return (
         <div>
           <p>Error occurs</p>
-          {/* <details style={{ whiteSpace: 'pre-wrap' }}>
-            {this.state.error && this.state.error.toString()}
-            <br />
-            {this.state.errorInfo.componentStack}
-          </details> */}
           <button
+            type="button"
             onClick={() => {
               window.location.reload();
             }}
             style={{
-              background: "none",
-              padding: "5px",
-              borderRadius: "5px",
-              boxShadow:"1px 1px 1px grey",
-              outline: "none",
-              cursor: "pointer"
+              background: 'none',
+              padding: '5px',
+              borderRadius: '5px',
+              boxShadow: '1px 1px 1px grey',
+              outline: 'none',
+              cursor: 'pointer',
             }}
           >
             Reload This Page
@@ -41,7 +34,6 @@ class ErrorBoundary extends React.Component {
         </div>
       );
     }
-    // Normally, just render children
     return this.props.children;
   }
 }

--- a/src/App/Components/Markdown/Previewer/Mermaid.jsx
+++ b/src/App/Components/Markdown/Previewer/Mermaid.jsx
@@ -1,9 +1,21 @@
 import React, { useEffect, useRef, useState } from 'react';
-import mermaid from 'mermaid';
 import { useThemeMode } from '../../../Theme';
 
+// The mermaid engine is the single heaviest dependency in the app. Load it
+// only when a diagram is actually rendered (dynamic import => its own chunk),
+// so the initial page load and the Header import of waitForMermaidRenders
+// below do not pull it into the main bundle. The module-level promise caches
+// the load so concurrent diagrams share one fetch.
+let mermaidPromise = null;
+const loadMermaid = () => {
+  if (!mermaidPromise) {
+    mermaidPromise = import('mermaid').then((m) => m.default || m);
+  }
+  return mermaidPromise;
+};
+
 let currentTheme = null;
-const initMermaid = (theme) => {
+const initMermaid = (mermaid, theme) => {
   if (currentTheme === theme) return;
   mermaid.initialize({
     startOnLoad: false,
@@ -36,7 +48,6 @@ export default function Mermaid({ code }) {
   const idRef = useRef(`mermaid-${++uid}`);
 
   useEffect(() => {
-    initMermaid(mermaidTheme);
     let cancelled = false;
     setFailed(false);
 
@@ -49,6 +60,8 @@ export default function Mermaid({ code }) {
 
     (async () => {
       try {
+        const mermaid = await loadMermaid();
+        initMermaid(mermaid, mermaidTheme);
         await mermaid.parse(code);
         const { svg: out } = await mermaid.render(idRef.current, code);
         if (!cancelled) setSvg(out);

--- a/src/App/Components/Markdown/index.js
+++ b/src/App/Components/Markdown/index.js
@@ -18,6 +18,27 @@ const Markdown = ({ className }) => {
   );
   const [activeTab, setActiveTab] = useState('editor');
   const markdownRef = useRef(null);
+  const editorTabRef = useRef(null);
+  const previewTabRef = useRef(null);
+
+  // Arrow-key roving between the two tabs (WAI-ARIA tabs pattern).
+  const handleTabKeyDown = (e) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const next = activeTab === 'editor' ? 'preview' : 'editor';
+      setActiveTab(next);
+      const ref = next === 'editor' ? editorTabRef : previewTabRef;
+      ref.current?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveTab('editor');
+      editorTabRef.current?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setActiveTab('preview');
+      previewTabRef.current?.focus();
+    }
+  };
   const [uploading, isOver] = useDrop(markdownRef, setText);
   const isMobile = useIsMobile();
 
@@ -84,22 +105,44 @@ const Markdown = ({ className }) => {
     >
       {isMobile ? (
         <>
-          <TabBar>
+          <TabBar role="tablist" aria-label="Editor and preview">
             <TabButton
+              ref={editorTabRef}
+              id="tab-editor"
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'editor'}
+              aria-controls="panel-editor"
+              tabIndex={activeTab === 'editor' ? 0 : -1}
               $active={activeTab === 'editor'}
               onClick={() => setActiveTab('editor')}
+              onKeyDown={handleTabKeyDown}
             >
               Editor
             </TabButton>
             <TabButton
+              ref={previewTabRef}
+              id="tab-preview"
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'preview'}
+              aria-controls="panel-preview"
+              tabIndex={activeTab === 'preview' ? 0 : -1}
               $active={activeTab === 'preview'}
               onClick={() => setActiveTab('preview')}
+              onKeyDown={handleTabKeyDown}
             >
               Preview
             </TabButton>
           </TabBar>
           <MobilePanel>
-            <MobilePane $hidden={activeTab !== 'editor'} className="no-print">
+            <MobilePane
+              id="panel-editor"
+              role="tabpanel"
+              aria-labelledby="tab-editor"
+              $hidden={activeTab !== 'editor'}
+              className="no-print"
+            >
               <Editor
                 text={text}
                 width={width}
@@ -107,7 +150,12 @@ const Markdown = ({ className }) => {
                 isMobile
               />
             </MobilePane>
-            <MobilePane $hidden={activeTab !== 'preview'}>
+            <MobilePane
+              id="panel-preview"
+              role="tabpanel"
+              aria-labelledby="tab-preview"
+              $hidden={activeTab !== 'preview'}
+            >
               <Previewer>{text}</Previewer>
             </MobilePane>
           </MobilePanel>
@@ -161,6 +209,15 @@ const TabButton = styled.button`
   &:hover {
     background-color: ${({ $active, theme }) =>
       $active ? theme.colors.tabActiveBg : theme.colors.tabInactiveHoverBg};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.focusRing};
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 `;
 

--- a/src/App/Container/Hooks/useText.js
+++ b/src/App/Container/Hooks/useText.js
@@ -1,5 +1,5 @@
-import  { useState } from "react";
-import { initialText } from "./InitialText.js";
+import { useState } from 'react';
+import { initialText } from './InitialText.js';
 const useText = (initialValue = initialText) => {
   const [state, setState] = useState(initialValue);
   return [state, setState];

--- a/src/App/Theme/index.js
+++ b/src/App/Theme/index.js
@@ -53,11 +53,12 @@ export const lightTheme = {
     dragBarActive: '#0984e3',
     tabBarBg: 'rgb(233, 233, 233)',
     tabBarBorder: 'rgba(0, 0, 0, 0.1)',
-    tabActiveBg: '#0984e3',
+    tabActiveBg: '#0969da',
     tabActiveText: '#fff',
     tabInactiveText: '#333',
     tabInactiveHoverBg: 'rgba(0,0,0,0.06)',
     accent: 'rgb(53, 123, 253)',
+    focusRing: '#0969da',
   },
 };
 
@@ -88,6 +89,7 @@ export const darkTheme = {
     tabInactiveText: '#c9d1d9',
     tabInactiveHoverBg: 'rgba(255,255,255,0.06)',
     accent: 'rgb(88, 166, 255)',
+    focusRing: '#58a6ff',
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,7 @@ const rootElement = document.getElementById('root');
 
 // [Prevent] The redirect of file drop
 window.addEventListener('drop', (e) => e.preventDefault(), true);
-// window.addEventListener('dragstart', e => e.preventDefault(), true);
 window.addEventListener('dragover', (e) => e.preventDefault(), true);
-// window.addEventListener('dragleave', e => e.preventDefault(), true);
 window.addEventListener('beforeunload', (e) => {
   const msg = 'Please check and backup the change before refresh or leave.';
   return ((e || window.event).returnValue = msg);

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,23 @@ header a {
   color: inherit;
 }
 
+/* Accessible focus indicator for the Upload control. It is a <p> wrapping a
+   visually-hidden file <input>, so the real focus lands on the input; we
+   surface the ring on the wrapping .button via :focus-within (styled-components
+   cannot target the parent from the inner input). The other header controls get
+   their :focus-visible ring from the theme token in Header/index.js. The color
+   here tracks the OS scheme as a fallback and is overridden in dark theme. */
+.button.upload:focus-within {
+  outline: 2px solid #0969da;
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .button.upload:focus-within {
+    outline-color: #58a6ff;
+  }
+}
+
 /* Preview layout tweaks (theme-neutral); colors come from the dynamically
    injected github-markdown light/dark stylesheet. */
 .preview.markdown-body {

--- a/vite.config.js
+++ b/vite.config.js
@@ -69,6 +69,43 @@ export default defineConfig(({ command }) => ({
       },
     }),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        // Split heavy vendors into their own long-lived, content-hashed chunks
+        // so the initial paint is not blocked by libraries that are only needed
+        // on demand. mermaid is dynamically imported (see Mermaid.jsx) and
+        // self-splits its diagram engines into many small chunks; forcing it
+        // into one manual chunk would coalesce those into a single >2MB file
+        // that exceeds workbox's precache limit, so it is intentionally left
+        // out of the rules below. The remaining large libs are kept out of the
+        // main bundle and cached independently across deploys. All emitted
+        // chunks match the PWA precache glob (**/*.js), so offline is unaffected.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined;
+          if (/[\\/]node_modules[\\/]highlight\.js[\\/]/.test(id))
+            return 'highlight';
+          if (
+            /[\\/]node_modules[\\/](@codemirror|@uiw|@lezer|codemirror)[\\/]/.test(
+              id,
+            )
+          )
+            return 'codemirror';
+          if (
+            /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)
+          )
+            return 'react';
+          if (
+            /[\\/]node_modules[\\/](react-markdown|remark-gfm|rehype-raw|rehype-sanitize|micromark|mdast-.*|hast-.*|unified|unist-.*)[\\/]/.test(
+              id,
+            )
+          )
+            return 'markdown';
+          return undefined;
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     strictPort: true,


### PR DESCRIPTION
## Summary

A four-track optimization pass across **performance/build**, **accessibility**, **SEO/metadata**, and **code quality**, with before/after screenshot verification at desktop, tablet, and mobile breakpoints. No behavior or layout regressions; the only intentional visual change is a darker light-mode active-tab blue for WCAG AA contrast. Offline-first, client-only, and the XSS sanitizer guarantees are all preserved.

Version bumped `2.10.6` → `2.11.0`; CHANGELOG updated. Merging this to `main` triggers the FTPS production deploy.

## Performance / build

- **Dynamically import Mermaid** (`Mermaid.jsx`) so the Header print path no longer pulls the ~2.8 MB engine into the entry bundle. `waitForMermaidRenders()` stays exported.
- **`manualChunks`** splits `react`, `codemirror`, `highlight.js`, and `markdown` into separate content-hashed vendor chunks. Mermaid is deliberately left out so it keeps its internal diagram-type splitting; coalescing it produced a single >2 MB chunk that exceeded workbox's precache limit and failed the build.
- **`.htaccess`**: hashed `assets/*` now `immutable, max-age=1yr`; `index.html`/`sw.js`/`manifest.json` stay `no-cache`.

## Accessibility

- Mobile/tablet Editor/Preview switcher is now a real ARIA tablist: `role=tablist/tab/tabpanel`, `aria-selected`, roving `tabindex`, and arrow/Home/End key navigation. Print behavior (both panes mounted) preserved.
- `:focus-visible` rings on all interactive controls via a new `focusRing` theme token; `prefers-reduced-motion` respected.
- File-import control is now keyboard-focusable (visually-hidden focusable input instead of `display:none`).
- Light active-tab blue `#0984e3` → `#0969da` (label contrast 3.87:1 → 5.19:1). All other palette colors verified AA-passing.

## SEO / metadata

- `index.html`: canonical, `og:url/type/site_name/locale`, `twitter:image:alt`, and a CSP-safe JSON-LD `WebApplication` block (no `'unsafe-inline'` added).
- `manifest.json` completed (`id`, `scope`, `start_url:'/'`, `categories`, `lang`, `dir`, `orientation`).
- The deliberate `noindex, nofollow` decision is **preserved**, not flipped.

## Code quality

- Removed dead/commented code across hooks, editor, and error boundaries; Previewer ErrorBoundary now logs errors instead of swallowing them.

## Tooling / docs

- `scripts/audit-screenshots.mjs` (Playwright) captures the key views at 1280/768/375. Output `screenshots/` is gitignored.
- `/audit` skill (`.claude/skills/audit/`) reproduces the full workflow.
- `CLAUDE.md` documents the chunking strategy, a11y contracts, metadata constraints, and audit workflow.

## Test plan

- [x] `npm test` (35/35 pass)
- [x] `npm run build` (succeeds; 109 precache entries, no chunk over the 2 MB limit)
- [x] `npm run changelog:lint`
- [x] Baseline vs after screenshots compared at desktop/tablet/mobile (incl. both tab states) — no layout regressions