### PR TITLE
release: v2.11.1 Firefox Android PDF filename and https redirect fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** for incomplete work.
 
+## [2.11.1] - 2026-06-09
+
+- **Fix:** Briefly reflect the heading in the URL while printing so Firefox Android names the exported PDF correctly.
+- **Sec:** Re-enable the http-to-https redirect in production so insecure requests are upgraded.
+- **Build:** Add an SPA fallback rewrite so the temporary print-time URL still serves the app on reload.
+
 ## [2.11.0] - 2026-06-04
 
 - **Enhance:** Mark the mobile Editor/Preview switcher as an ARIA tablist with roving tabindex and arrow-key navigation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "packageManager": "npm@10.9.3",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -315,15 +315,15 @@ AddDefaultCharset utf-8
 #     https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml
 #     https://tools.ietf.org/html/draft-ietf-acme-acme-12
 
-# <IfModule mod_rewrite.c>
-#    RewriteEngine On
-#    RewriteCond %{HTTPS} !=on
-#    # (1)
-#    # RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
-#    # RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[\w-]+$
-#    # RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
-#    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-# </IfModule>
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on
+    # (1) Exclude ACME / domain-validation paths so HTTP cert renewal keeps working.
+    RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
+    RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[\w-]+$
+    RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+</IfModule>
 
 # ----------------------------------------------------------------------
 # | Suppressing the `www.` at the beginning of URLs                    |
@@ -411,6 +411,26 @@ AddDefaultCharset utf-8
 #     RewriteRule ^ %{ENV:PROTO}://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 # </IfModule>
+
+# ----------------------------------------------------------------------
+# | Single-page-app fallback                                           |
+# ----------------------------------------------------------------------
+
+# The app briefly rewrites the URL path to a heading slug while printing so
+# Firefox on Android names the exported PDF from the path. Those paths are not
+# real files, so serve `index.html` for any request that does not map to an
+# existing file or directory. Hashed assets, the service worker, and the
+# manifest all resolve to real files and are unaffected.
+
+<IfModule mod_rewrite.c>
+
+    RewriteEngine On
+
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^ /index.html [L]
+
+</IfModule>
 
 # ######################################################################
 # # SECURITY                                                           #

--- a/src/App/Components/Header/index.js
+++ b/src/App/Components/Header/index.js
@@ -9,6 +9,7 @@ import {
 } from 'react-bootstrap-icons';
 import UploadButton from './Upload.js';
 import { waitForMermaidRenders } from '../Markdown/Previewer/Mermaid.jsx';
+import { toFilenameSlug } from '../../Lib/printTitle.js';
 import { useThemeMode } from '../../Theme';
 import packageMeta from '../../../../package.json';
 
@@ -32,12 +33,39 @@ const Header = ({ className }) => {
   const { mode, cycleMode } = useThemeMode();
   const ThemeIcon = THEME_ICON[mode] || CircleHalf;
 
-  // The Markdown component keeps document.title synced to the first heading
-  // so that any print path (this button, Ctrl/Cmd+P, browser menu, Android
-  // share-to-PDF) reads the right value. See src/App/Lib/printTitle.js.
+  // The Markdown component keeps document.title synced to the first heading so
+  // Chromium and desktop browsers suggest a heading-based PDF filename. Firefox
+  // on Android ignores the title and derives the name from the URL path, so we
+  // briefly rewrite the path to a heading slug for the duration of the print,
+  // then restore it. navigateFallback ('/index.html') and the .htaccess SPA
+  // rule keep that throwaway path loadable if the user reloads before restore.
   const onTransform = async () => {
+    const slug = toFilenameSlug(document.title);
+    const { pathname, search, hash } = window.location;
+    const originalUrl = pathname + search + hash;
+
+    let restored = false;
+    const handleVisible = () => {
+      if (document.visibilityState === 'visible') restore();
+    };
+    const restore = () => {
+      if (restored) return;
+      restored = true;
+      window.removeEventListener('afterprint', restore);
+      document.removeEventListener('visibilitychange', handleVisible);
+      window.history.replaceState(null, '', originalUrl);
+    };
+
     try {
       await waitForMermaidRenders();
+      if (slug) {
+        window.history.replaceState(null, '', `/${slug}`);
+        // afterprint covers desktop/Chromium (fires when the dialog closes);
+        // returning to a visible tab covers Android, where afterprint is
+        // unreliable and the filename is captured during the system print UI.
+        window.addEventListener('afterprint', restore);
+        document.addEventListener('visibilitychange', handleVisible);
+      }
     } finally {
       window.print();
     }

--- a/src/App/Lib/printTitle.js
+++ b/src/App/Lib/printTitle.js
@@ -1,5 +1,20 @@
 export const DEFAULT_TITLE = 'Markdown to PDF';
 
+// Firefox on Android derives the saved/printed PDF name from the document URL
+// (via GeckoView's guessFileName), not document.title, so the continuous title
+// sync that fixes Chromium and desktop has no effect there. The print handler
+// briefly rewrites the URL path to this slug so Firefox names the file from the
+// heading. Keep it ASCII path-safe: collapse every non-alphanumeric run to a
+// single hyphen and cap the length so the path stays short.
+export const toFilenameSlug = (raw) =>
+  (raw ?? '')
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .replace(/^-+/, '')
+    .slice(0, 100)
+    .replace(/-+$/, '');
+
 export const sanitizeForFilename = (raw) =>
   (raw ?? '')
     .replace(/[\\/:*?"<>|\r\n\t]+/g, ' ')

--- a/src/App/Lib/printTitle.test.js
+++ b/src/App/Lib/printTitle.test.js
@@ -3,6 +3,7 @@ import {
   DEFAULT_TITLE,
   extractHeading,
   sanitizeForFilename,
+  toFilenameSlug,
 } from './printTitle.js';
 
 describe('sanitizeForFilename', () => {
@@ -96,6 +97,38 @@ describe('extractHeading', () => {
     expect(extractHeading('    # not a heading\n\n# Real one')).toBe(
       'Real one',
     );
+  });
+});
+
+describe('toFilenameSlug', () => {
+  test('hyphenates spaces and drops trailing punctuation', () => {
+    expect(toFilenameSlug('Hello World!')).toBe('Hello-World');
+  });
+
+  test('collapses runs of non-alphanumerics into single hyphens', () => {
+    expect(toFilenameSlug('foo / bar : baz')).toBe('foo-bar-baz');
+  });
+
+  test('trims leading and trailing hyphens', () => {
+    expect(toFilenameSlug('  --weird-- ')).toBe('weird');
+  });
+
+  test('transliterates accented characters to ASCII', () => {
+    expect(toFilenameSlug('Café Résumé')).toBe('Cafe-Resume');
+  });
+
+  test('caps the length so the URL path stays short', () => {
+    expect(toFilenameSlug('a'.repeat(200))).toHaveLength(100);
+  });
+
+  test('returns empty string for empty or null input', () => {
+    expect(toFilenameSlug('')).toBe('');
+    expect(toFilenameSlug(null)).toBe('');
+    expect(toFilenameSlug(undefined)).toBe('');
+  });
+
+  test('returns empty string when nothing alphanumeric remains', () => {
+    expect(toFilenameSlug('!!! ??? ...')).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary

- **Firefox Android PDF filename:** Firefox on Android derives the saved/printed PDF name from the document URL (via GeckoView's `guessFileName`), not `document.title`. The existing continuous title sync fixes Chromium and desktop but has no effect on Firefox Android, which falls back to a generic `temp…` name at the root path `/`. The print handler now briefly rewrites the URL path to a heading slug for the duration of the print and restores it on `afterprint` or when the tab becomes visible again.
- **https redirect:** The "Forcing https" block in `public/.htaccess` was entirely commented out, so insecure http requests were never upgraded. Re-enabled it (keeping ACME / domain-validation paths excluded so cert renewal still works).
- **SPA fallback:** Added a rewrite so the throwaway print-time URL still serves `index.html` on reload; the PWA `navigateFallback` already covers the offline case.

## Changes

- `src/App/Lib/printTitle.js`: new `toFilenameSlug` helper (+ tests).
- `src/App/Components/Header/index.js`: transient URL-slug logic in the print handler.
- `public/.htaccess`: enable http→https redirect, add SPA fallback rewrite.
- `package.json` / `CHANGELOG.md`: bump to 2.11.1.

## Test plan

- [x] `npm test` — 42 passing (7 new `toFilenameSlug` cases).
- [x] `npm run build` — succeeds, PWA precache intact.
- [x] `npm run changelog:lint` — OK.
- [ ] Manual: print on Firefox Android and confirm the suggested PDF filename matches the first heading.
- [ ] Manual: confirm http→https redirect on production after deploy.