### PR TITLE
fix: keep tab title as Markdown to PDF, set heading only on export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; add **(WIP)** for incomplete work.
 
+## [2.11.3] - 2026-06-10
+
+- **Fix:** Keep the browser tab titled "Markdown to PDF" and apply the heading only while exporting.
+- **Chore:** Remove the Firefox Android URL-slug print hack that never controlled the PDF filename.
+
 ## [2.11.2] - 2026-06-09
 
 - **Build:** Bump the npm minor/patch group: React 19.2.7, styled-components 6.4.2, CodeMirror, Workbox, and Vite/Vitest tooling.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md2pdf",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "packageManager": "npm@10.9.3",
   "description": "Mobile-friendly Markdown to PDF in your browser with GFM, syntax highlighting, and Mermaid. Works offline; nothing is uploaded for conversion. Fork of realdennis/md2pdf (MIT).",
   "keywords": [

--- a/src/App/Components/Header/index.js
+++ b/src/App/Components/Header/index.js
@@ -7,9 +7,11 @@ import {
   MoonFill,
   SunFill,
 } from 'react-bootstrap-icons';
+import { useProvided } from 'nonaction';
 import UploadButton from './Upload.js';
 import { waitForMermaidRenders } from '../Markdown/Previewer/Mermaid.jsx';
-import { toFilenameSlug } from '../../Lib/printTitle.js';
+import { DEFAULT_TITLE, extractHeading } from '../../Lib/printTitle.js';
+import { TextContainer } from '../../Container';
 import { useThemeMode } from '../../Theme';
 import packageMeta from '../../../../package.json';
 
@@ -32,42 +34,21 @@ const NEXT_MODE_LABEL = {
 const Header = ({ className }) => {
   const { mode, cycleMode } = useThemeMode();
   const ThemeIcon = THEME_ICON[mode] || CircleHalf;
+  const [text] = useProvided(TextContainer);
 
-  // The Markdown component keeps document.title synced to the first heading so
-  // Chromium and desktop browsers suggest a heading-based PDF filename. Firefox
-  // on Android ignores the title and derives the name from the URL path, so we
-  // briefly rewrite the path to a heading slug for the duration of the print,
-  // then restore it. navigateFallback ('/index.html') and the .htaccess SPA
-  // rule keep that throwaway path loadable if the user reloads before restore.
+  // The tab title stays DEFAULT_TITLE; the heading is applied as document.title
+  // only for the duration of the print so desktop and Chromium suggest a
+  // heading-based PDF filename (both read the title at window.print()). Firefox
+  // on Android assigns the name at the OS/GeckoView level and is not
+  // controllable from web content, so it is unaffected here.
   const onTransform = async () => {
-    const slug = toFilenameSlug(document.title);
-    const { pathname, search, hash } = window.location;
-    const originalUrl = pathname + search + hash;
-
-    let restored = false;
-    const handleVisible = () => {
-      if (document.visibilityState === 'visible') restore();
-    };
-    const restore = () => {
-      if (restored) return;
-      restored = true;
-      window.removeEventListener('afterprint', restore);
-      document.removeEventListener('visibilitychange', handleVisible);
-      window.history.replaceState(null, '', originalUrl);
-    };
-
+    const heading = extractHeading(text);
     try {
       await waitForMermaidRenders();
-      if (slug) {
-        window.history.replaceState(null, '', `/${slug}`);
-        // afterprint covers desktop/Chromium (fires when the dialog closes);
-        // returning to a visible tab covers Android, where afterprint is
-        // unreliable and the filename is captured during the system print UI.
-        window.addEventListener('afterprint', restore);
-        document.addEventListener('visibilitychange', handleVisible);
-      }
     } finally {
+      if (heading) document.title = heading;
       window.print();
+      document.title = DEFAULT_TITLE;
     }
   };
 

--- a/src/App/Components/Markdown/index.js
+++ b/src/App/Components/Markdown/index.js
@@ -7,7 +7,7 @@ import Editor from './Editor';
 import DragBar from './DragBar.js';
 import useDrop from '../../Container/Hooks/useDrop.js';
 import useIsMobile from '../../Container/Hooks/useIsMobile.js';
-import { DEFAULT_TITLE, extractHeading } from '../../Lib/printTitle.js';
+import { DEFAULT_TITLE } from '../../Lib/printTitle.js';
 
 const Markdown = ({ className }) => {
   const [text, setText] = useProvided(TextContainer);
@@ -66,22 +66,11 @@ const Markdown = ({ className }) => {
     };
   }, []);
 
-  // Keep document.title synced to the first heading so the suggested PDF
-  // filename is correct on every print path. Android Firefox does not fire
-  // beforeprint reliably (saves as tempXXXX) and Chromium-on-Android reads
-  // document.title at window.print() invocation, so a beforeprint swap can
-  // arrive too late. A continuous sync makes the title correct in advance.
+  // The tab title stays the app name; the Header's export handler applies the
+  // heading as document.title only for the duration of the print.
   useEffect(() => {
-    const originalTitle = document.title;
-    return () => {
-      document.title = originalTitle;
-    };
+    document.title = DEFAULT_TITLE;
   }, []);
-
-  useEffect(() => {
-    const heading = extractHeading(text);
-    document.title = heading || DEFAULT_TITLE;
-  }, [text]);
 
   const handleMouseMove = (e) => {
     if (!isDrag) return;

--- a/src/App/Lib/printTitle.js
+++ b/src/App/Lib/printTitle.js
@@ -1,20 +1,5 @@
 export const DEFAULT_TITLE = 'Markdown to PDF';
 
-// Firefox on Android derives the saved/printed PDF name from the document URL
-// (via GeckoView's guessFileName), not document.title, so the continuous title
-// sync that fixes Chromium and desktop has no effect there. The print handler
-// briefly rewrites the URL path to this slug so Firefox names the file from the
-// heading. Keep it ASCII path-safe: collapse every non-alphanumeric run to a
-// single hyphen and cap the length so the path stays short.
-export const toFilenameSlug = (raw) =>
-  (raw ?? '')
-    .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/[^A-Za-z0-9]+/g, '-')
-    .replace(/^-+/, '')
-    .slice(0, 100)
-    .replace(/-+$/, '');
-
 export const sanitizeForFilename = (raw) =>
   (raw ?? '')
     .replace(/[\\/:*?"<>|\r\n\t]+/g, ' ')

--- a/src/App/Lib/printTitle.test.js
+++ b/src/App/Lib/printTitle.test.js
@@ -3,7 +3,6 @@ import {
   DEFAULT_TITLE,
   extractHeading,
   sanitizeForFilename,
-  toFilenameSlug,
 } from './printTitle.js';
 
 describe('sanitizeForFilename', () => {
@@ -97,38 +96,6 @@ describe('extractHeading', () => {
     expect(extractHeading('    # not a heading\n\n# Real one')).toBe(
       'Real one',
     );
-  });
-});
-
-describe('toFilenameSlug', () => {
-  test('hyphenates spaces and drops trailing punctuation', () => {
-    expect(toFilenameSlug('Hello World!')).toBe('Hello-World');
-  });
-
-  test('collapses runs of non-alphanumerics into single hyphens', () => {
-    expect(toFilenameSlug('foo / bar : baz')).toBe('foo-bar-baz');
-  });
-
-  test('trims leading and trailing hyphens', () => {
-    expect(toFilenameSlug('  --weird-- ')).toBe('weird');
-  });
-
-  test('transliterates accented characters to ASCII', () => {
-    expect(toFilenameSlug('Café Résumé')).toBe('Cafe-Resume');
-  });
-
-  test('caps the length so the URL path stays short', () => {
-    expect(toFilenameSlug('a'.repeat(200))).toHaveLength(100);
-  });
-
-  test('returns empty string for empty or null input', () => {
-    expect(toFilenameSlug('')).toBe('');
-    expect(toFilenameSlug(null)).toBe('');
-    expect(toFilenameSlug(undefined)).toBe('');
-  });
-
-  test('returns empty string when nothing alphanumeric remains', () => {
-    expect(toFilenameSlug('!!! ??? ...')).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary
- Tab title now stays **Markdown to PDF** at all times; the first heading is applied as `document.title` only for the duration of the export `window.print()` call (when desktop/Chromium capture the suggested filename), then restored.
- Removes the v2.11.1 Firefox Android URL-slug rewrite (`history.replaceState` + restore listeners). Evidence (Bugzilla 1815195, GeckoView Save-to-PDF docs) shows GeckoView assigns the `window.print()` filename at the OS level and ignores both `document.title` and the URL, so the hack never controlled the filename.
- Drops the now-unused `toFilenameSlug` helper and its tests.

## Test plan
- [x] `npm test` (35 passing)
- [x] `npm run build`
- [x] `npm run changelog:lint`
- [x] Playwright check: tab title is "Markdown to PDF" on load and while typing a heading; `document.title` is the heading at `window.print()` invocation; restored to "Markdown to PDF" after.
- [ ] Firefox Android on-device: confirm exported PDF filename behavior (OS-level limitation; verified by maintainer).